### PR TITLE
Apply fix to allow project compile using Java 8

### DIFF
--- a/gsf-sample-avisports/pom.xml
+++ b/gsf-sample-avisports/pom.xml
@@ -28,6 +28,19 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+        <profile>
+        <id>disable-java8-doclint</id>
+        <activation>
+            <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+            <additionalparam>-Xdoclint:none</additionalparam>
+        </properties>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>

--- a/gsf-sample/pom.xml
+++ b/gsf-sample/pom.xml
@@ -31,6 +31,17 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+  <profiles>
+        <profile>
+        <id>disable-java8-doclint</id>
+        <activation>
+            <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+            <additionalparam>-Xdoclint:none</additionalparam>
+        </properties>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>
@@ -65,6 +76,7 @@
         <executions>
           <execution>
             <id>attach-javadocs</id>
+
             <phase>install</phase>
             <goals>
               <goal>jar</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
       <name>Tony Field</name>
     </developer>
   </developers>
+
+
   <scm>
     <connection>scm:git:git@github.com:dolfdijkstra/gst-foundation.git</connection>
     <developerConnection>scm:git:git@github.com:dolfdijkstra/gst-foundation.git</developerConnection>
@@ -247,7 +249,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.3</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -339,6 +341,15 @@
         <module>gsf-sample</module>
         <module>gsf-sample-avisports</module>
       </modules>
+    </profile>
+      <profile>
+        <id>disable-java8-doclint</id>
+        <activation>
+            <jdk>[1.8,)</jdk>
+        </activation>
+        <properties>
+            <additionalparam>-Xdoclint:none</additionalparam>
+        </properties>
     </profile>
   </profiles>
   <distributionManagement>


### PR DESCRIPTION
Update adds profile activation in 3 pom files when using jdk 1.8, an additional parameter is included that causes doclint and javadoc 'errors' to be skipped over for now.

jdk 1.8 requires that all javadocs conform to W3C HTML 4.01 HTML, and any offending javadoc values cause an **error**, not a warning, and halts the build. While working to update javadocs in gsf, this will at least allow the package to compile and build in the meantime. 

